### PR TITLE
Update Java3d and Vecmath dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>ij</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>3D_Viewer</artifactId>
+			<version>4.0.2-SNAPSHOT</version>
+		</dependency>
         <!--
         <dependency>
                 <groupId>net.imagej</groupId>
@@ -71,19 +76,19 @@
         </dependency>
         -->
         <dependency>
-            <groupId>java3d</groupId>
-            <artifactId>j3d-core</artifactId>
-            <version>RELEASE</version>
+            <groupId>org.scijava</groupId>
+            <artifactId>j3dcore</artifactId>
+            <version>1.6.0-scijava-2</version>
         </dependency>
         <dependency>
-            <groupId>java3d</groupId>
-            <artifactId>j3d-core-utils</artifactId>
-            <version>RELEASE</version>
+            <groupId>org.scijava</groupId>
+            <artifactId>j3dutils</artifactId>
+            <version>1.6.0-scijava-2</version>
         </dependency>
         <dependency>
-            <groupId>java3d</groupId>
+            <groupId>org.scijava</groupId>
             <artifactId>vecmath</artifactId>
-            <version>RELEASE</version>
+            <version>1.6.0-scijava-2</version>
         </dependency>
         <!--
        <dependency>
@@ -112,7 +117,7 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>3D_Viewer</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.1</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -165,7 +170,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <source>1.6</source>

--- a/src/main/java/mcib3d/geom/MeshEditor.java
+++ b/src/main/java/mcib3d/geom/MeshEditor.java
@@ -4,7 +4,7 @@
 package mcib3d.geom;
 
 import java.util.*;
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /**
  *

--- a/src/main/java/mcib3d/geom/Object3DSurface.java
+++ b/src/main/java/mcib3d/geom/Object3DSurface.java
@@ -21,9 +21,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.vecmath.Color3f;
-import javax.vecmath.Point3f;
-import javax.vecmath.Vector3f;
+import org.scijava.vecmath.Color3f;
+import org.scijava.vecmath.Point3f;
+import org.scijava.vecmath.Vector3f;
 import mcib3d.image3d.ImageFloat;
 import mcib3d.image3d.ImageHandler;
 import mcib3d.utils.ArrayUtil;
@@ -1956,6 +1956,7 @@ public class Object3DSurface extends Object3D {
 
     public Content drawContent(Image3DUniverse univ, Color3f co, String name) {
         //List<org.scijava.vecmath.Point3f> test=faces;
+        univ.addTriangleMesh(faces, co, name);
         univ.addTriangleMesh(faces, co, name);
         return univ.addTriangleMesh(faces, co, name);
     }

--- a/src/main/java/mcib3d/geom/Point3D.java
+++ b/src/main/java/mcib3d/geom/Point3D.java
@@ -1,7 +1,7 @@
 package mcib3d.geom;
 
 import java.util.Random;
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /**
  * Copyright (C) Thomas Boudier

--- a/src/main/java/mcib3d/geom/Vector3D.java
+++ b/src/main/java/mcib3d/geom/Vector3D.java
@@ -1,7 +1,7 @@
 package mcib3d.geom;
 
 import java.text.NumberFormat;
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /**
  * Copyright (C) Thomas Boudier

--- a/src/main/java/mcib3d/geom/Voxel3D.java
+++ b/src/main/java/mcib3d/geom/Voxel3D.java
@@ -1,6 +1,6 @@
 package mcib3d.geom;
 
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /**
  * Copyright (C) Thomas Boudier

--- a/src/main/java/mcib3d/geom/deformation3d/DeformableMesh.java
+++ b/src/main/java/mcib3d/geom/deformation3d/DeformableMesh.java
@@ -7,7 +7,7 @@ package mcib3d.geom.deformation3d;
 import ij.IJ;
 import java.util.ArrayList;
 import java.util.List;
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 import mcib3d.geom.GeomTransform3D;
 import mcib3d.geom.Object3DSurface;
 import mcib3d.geom.Point3D;

--- a/src/main/java/mcib3d/geom/deformation3d/Deriche.java
+++ b/src/main/java/mcib3d/geom/deformation3d/Deriche.java
@@ -2,8 +2,8 @@ package mcib3d.geom.deformation3d;
 
 import ij.ImageStack;
 import java.util.ArrayList;
-import javax.vecmath.Point3f;
-import javax.vecmath.Vector3d;
+import org.scijava.vecmath.Point3f;
+import org.scijava.vecmath.Vector3d;
 import mcib3d.geom.Voxel3D;
 
 

--- a/src/main/java/mcib3d/geom/deformation3d/Mesh.java
+++ b/src/main/java/mcib3d/geom/deformation3d/Mesh.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 import mcib3d.geom.Object3DSurface;
 import mcib3d.geom.Voxel3D;
 //import com.sun.j3d.*;

--- a/src/main/java/mcib3d/geom/deformation3d/Vertex.java
+++ b/src/main/java/mcib3d/geom/deformation3d/Vertex.java
@@ -5,7 +5,7 @@
 package mcib3d.geom.deformation3d;
 
 import java.util.ArrayList;
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /**
  *

--- a/src/main/java/mcib3d/utils/CheckInstall.java
+++ b/src/main/java/mcib3d/utils/CheckInstall.java
@@ -54,7 +54,7 @@ public class CheckInstall {
 //            ij.IJ.log("Image5D not installed: overlay view not available");
 //        }
         try {
-            loader.loadClass("javax.vecmath.Point3f");
+            loader.loadClass("org.scijava.vecmath.Point3f");
         } catch (Exception e) {
             ij.IJ.log("Java3D not installed. ");
         }


### PR DESCRIPTION
to be compatible with current Fiji (Java8) installations.

See https://github.com/mcib3d/mcib3d-core/issues/4.
