### PR TITLE
Use Point3f and Vector3d from scijava

### DIFF
--- a/src/main/java/mcib3d/geom/deformation3d/Deriche.java
+++ b/src/main/java/mcib3d/geom/deformation3d/Deriche.java
@@ -2,8 +2,8 @@ package mcib3d.geom.deformation3d;
 
 import ij.ImageStack;
 import java.util.ArrayList;
-import javax.vecmath.Point3f;
-import javax.vecmath.Vector3d;
+import org.scijava.vecmath.Point3f;
+import org.scijava.vecmath.Vector3d;
 import mcib3d.geom.Voxel3D;
 
 


### PR DESCRIPTION
Deriche.java was not yet changed to use the SciJava vecmath dependencies.
