### PR TITLE
Add method for Centroid coordinates with unit

### DIFF
--- a/src/main/java/mcib3d/geom/Objects3DPopulation.java
+++ b/src/main/java/mcib3d/geom/Objects3DPopulation.java
@@ -1746,6 +1746,17 @@ public class Objects3DPopulation {
 
         return al;
     }
+    
+    public List<Double[]> getMeasureCentroidUnit() {
+        // geometrical measure volume (pix and unit) and surface (pix and unit)
+        ArrayList<Double[]> al = new ArrayList<>();
+        for (Object3D ob : objects) {
+            Double[] mes = new Double[]{(double) ob.getValue(), ob.getCenterX() * obj.resXY ob.getCenterY() * ob.resXY, ob.getCenterZ() * ob.resZ};
+            al.add(mes);
+        }
+
+        return al;
+    }
 
     public List<Double[]> getMeasuresShape() {
         List<Double[]> al = new ArrayList<>();


### PR DESCRIPTION
As the getMeasureCentroid is in pixels, another method to get it calibrated would make sense.